### PR TITLE
Implemented a parsing of robot id that should be a little bit more robust.

### DIFF
--- a/loop-functions/vanilla/ForagingTwoSpotsLoopFunc.cpp
+++ b/loop-functions/vanilla/ForagingTwoSpotsLoopFunc.cpp
@@ -101,7 +101,13 @@ void ForagingTwoSpotsLoopFunction::PostStep() {
   UInt32 unId;
   for (CSpace::TMapPerType::iterator it = tEpuckMap.begin(); it != tEpuckMap.end(); ++it) {
     CEPuckEntity* pcEpuck = any_cast<CEPuckEntity*>(it->second);
-    unId = atoi(pcEpuck->GetId().substr(5, 2).c_str());
+    // unId = atoi(pcEpuck->GetId().substr(5, 2).c_str());
+    // expects the id to be in the following form: epuck_{unId}_{robotId}
+    std::string robot_id = pcEpuck->GetId();
+    UInt8 first_underscore = robot_id.find("_");
+    UInt8 second_underscore = robot_id.find("_", first_underscore+1);
+    robot_id = robot_id.substr(first_underscore, second_underscore-first_underscore);
+    unId = atoi(robot_id.c_str());
     cEpuckPosition.Set(pcEpuck->GetEmbodiedEntity().GetOriginAnchor().Position.GetX(),
                        pcEpuck->GetEmbodiedEntity().GetOriginAnchor().Position.GetY());
 
@@ -114,9 +120,9 @@ void ForagingTwoSpotsLoopFunction::PostStep() {
     } else if (cEpuckPosition.GetY() <= m_fNestLimit) {
       m_fObjectiveFunction = m_fObjectiveFunction + m_punFoodData[unId];
       m_punFoodData[unId] = 0;
+      // LOG << "Obj " << m_fObjectiveFunction << std::endl;
     }
   }
-  //LOG << "Obj " << m_fObjectiveFunction << std::endl;
 }
 
 /****************************************/


### PR DESCRIPTION
The current loop function is to easily broken (basically when the two numbers for the id do not start at the sixth letter). If this is not met, than the unId will be interpreted as zero and weird behaviors can occur. I have written a parsing for the id that should be a little bit more robust to different naming conventions. It assumes two things: 

1. The id of the epuck contains at least two underscores.
2. The id for argos is located between the first and the second underscore

This should work fine with a pattern like epuck_{argosId}_{hardwareId}, but I'm not sure anymore if this is the format that we need for the real robot experiments.